### PR TITLE
Add dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ xed .
 - `Song`: Manages individual song data and audio features
 - `AudioFeatures`: Captures audio analysis results
 
+## US Tree Dashboard Development
+Development of the dashboard used for analyzing tree data occurs in a separate repository. See [README_US_TREE_DASHBOARD.md](README_US_TREE_DASHBOARD.md) for instructions on creating a Python environment and running its tests.
+
 ## Contributing
 
 1. Fork the repository

--- a/README_US_TREE_DASHBOARD.md
+++ b/README_US_TREE_DASHBOARD.md
@@ -1,0 +1,27 @@
+# US Tree Dashboard Environment Setup
+
+These steps set up the **us-tree-dashboard** repository for local development and testing.
+
+## 1. Clone the repository
+```bash
+git clone https://github.com/kakashi3lite/us-tree-dashboard
+cd us-tree-dashboard
+```
+
+## 2. Configure environment variables
+Copy `.env.example` to `.env` and add your `OPENAI_API_KEY` along with any other required values.
+
+## 3. Install dependencies
+Create a Python 3.11 virtual environment and install the required packages:
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt pytest-cov openai
+```
+
+## 4. Run the tests
+```bash
+python -m pytest
+```
+
+All tests should succeed once dependencies are installed and code fixes are applied.


### PR DESCRIPTION
## Summary
- rename dashboard setup guide to match repo docs
- link US Tree Dashboard instructions from main README
- ensure newline at end of README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b286ac4c8330add01a2b032e7240